### PR TITLE
s-salome-ng: append s-salome-openturns

### DIFF
--- a/scripts.d/.plan-ng-dev
+++ b/scripts.d/.plan-ng-dev
@@ -13,6 +13,7 @@ s-cmake/native
         s-paravisaddons-edf
         s-atomic
         s-persalys:v11.0rc1
+        s-salome-openturns
 ] /linux
 
 #  The version has two parts, the version of the code and the version

--- a/scripts.d/s-salome-ng
+++ b/scripts.d/s-salome-ng
@@ -4,6 +4,7 @@ function s-salome-ng-modules()
     echo s-atomic
     echo s-paravisaddons-edf
     echo s-persalys
+    echo s-salome-openturns
 }
 
 function setup-salome-ng-env()

--- a/scripts.d/s-salome-openturns
+++ b/scripts.d/s-salome-openturns
@@ -17,36 +17,46 @@ function s-salome-openturns-tar()
     echo OPENTURNS_SRC_$VERSION.tgz
 }
 
-function s-salome-openturns-build-depends()
+function s-salome-openturns-common-build-depends()
+{
+    echo s-cmake
+}
+
+function s-salome-openturns-default-build-depends()
 {
     echo os@-python3-sphinx
     echo os@-swig
     echo os@-graphviz-dev
     echo os@-doxygen
     echo os@-python3-docutils
-
-    echo s-cmake
-    echo s-salome-configuration
 }
 
-function s-salome-openturns-depends()
+function s-salome-openturns-common-depends()
+{
+    echo s-salome-configuration
+    echo s-persalys
+}
+
+function s-salome-openturns-default-depends()
 {
     echo os@-qt5-default
     echo os@-qtbase5-dev
 
-    echo s-persalys
     echo s-salome-kernel
+    echo s-salome-gui
     echo s-openturns
     echo s-yacs
+}
+
+function s-salome-openturns-linux-depends()
+{
+    echo s-salome-bin
 }
 
 function s-salome-openturns-env()
 {
     local PREFIX=$1
     local TARGET=$2
-
-    # Use system Qt5
-    set-var    QT5_ROOT_DIR       /usr
 
     set-var    OPENTURNS_ROOT_DIR $PREFIX
 
@@ -63,7 +73,6 @@ function s-salome-openturns-config()
     local CDEBUG=$(is-enabled cmake-debug)
 
     cmake -DCMAKE_INSTALL_PREFIX=$PREFIX \
-          -DCMAKE_PREFIX_PATH=$PREFIX/lib/cmake \
           -DCMAKE_BUILD_TYPE=$(get-build-type CMAKE Release) \
           ${CDEBUG:+"-DSALOME_CMAKE_DEBUG=ON"} ../src
 }


### PR DESCRIPTION
Salut Pascal,
J'ai ajouté le module salome-openturns dans salome-ng pour avoir l'icon persalys dans salome-gui. J'ai testé sur sci9 et ça marche. Sinon, il faut ajouter aussi le lien de test install_salome-openturns/bin/salome/test dans BINARIES-DB*/SALOME/bin/salome/test/CTestTestFile.cmake. Je voudrais bien qu'on regarde ensemble sur ce problème cet aprèm. Je serai dispo à 14h30

A+