### PR TITLE
s-salome: minor correction to have the right python launcher

### DIFF
--- a/scripts.d/s-salome
+++ b/scripts.d/s-salome
@@ -296,6 +296,7 @@ function build-salome-context()
         echo "LC_NUMERIC=C"                                             >> $FILE
         echo "ADD_TO_SALOME_PLUGINS_PATH:\"%(ROOT_EXTERNAL)s/plugins\"" >> $FILE
         echo "ADD_TO_PV_PLUGIN_PATH: \"%(ROOT_INSTALL)s/lib/paraview\"" >> $FILE
+        echo "ADD_TO_PATH: \"%(ROOT_INSTALL)s/bin/salome\""             >> $FILE
 
         for-all-modules-with-meta env-callback s-salome
     )


### PR DESCRIPTION
Salut Pascal,

J'ai trouvé que la méthode qu'on a utilisé hier pour modifier l'ordre de la liste des fichier cfg, n'est pas bon. La fonction de python qui récupère des .cfg est glob. Et l'ordre du retour de cette fonction est celui dans lequel les entrées apparaissent dans le filesystem (l'ordre de ls -U). Donc il est vraiment aléatoire. Donc  Je pense que c'est mieux qu'on déclare un path appli/bin/salome directement dans envProducts.cfg pour être sûre qu'il est toujour avant /usr/bin.

A+
Duc 