### PR TITLE
activate HOMARD TESTS, MEDCOUPLING TESTS, and fix MEDCALC TESTS

### DIFF
--- a/scripts.d/patches/to_active_homard_test.patch
+++ b/scripts.d/patches/to_active_homard_test.patch
@@ -1,0 +1,25 @@
+From b497262a3386b556900a1837a364136a643c68f3 Mon Sep 17 00:00:00 2001
+From: DUC ANH HOANG <duc-anh-externe.hoang@edf.fr>
+Date: Wed, 16 Mar 2022 14:51:43 +0100
+Subject: [PATCH] [PATCH] to install the homard test in edf env
+
+---
+ src/tests/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/tests/CMakeLists.txt b/src/tests/CMakeLists.txt
+index d17e1fc..5a4c85a 100644
+--- a/src/tests/CMakeLists.txt
++++ b/src/tests/CMakeLists.txt
+@@ -16,7 +16,7 @@
+ #
+ # See http://www.salome-platform.org/ or email : webmaster.salome@opencascade.com
+ #
+-
++SET(MED_INT_IS_LONG TRUE)
+ IF(MED_INT_IS_LONG)
+   # Homard tests are unavailable if medfile is built with 32-bits UIDs
+   IF(SALOME_BUILD_TESTS)
+-- 
+2.20.1
+

--- a/scripts.d/s-homard
+++ b/scripts.d/s-homard
@@ -26,6 +26,17 @@ function s-homard-tar()
     echo HOMARD_SRC_$VERSION.tgz
 }
 
+function s-homard-patches()
+{
+    local PREFIX=$1
+    local TARGET=$2
+    local VARIANT=$3
+    local KIND=$4
+    local REF=$5
+
+    echo to_active_homard_test.patch
+}
+
 function s-homard-build-depends()
 {
     echo s-cmake

--- a/scripts.d/s-paravisaddons-common
+++ b/scripts.d/s-paravisaddons-common
@@ -104,6 +104,16 @@ function s-paravisaddons-common-install()
     make install
 }
 
+function s-paravisaddons-common-post-install()
+{
+    local PREFIX=$1
+    local TARGET=$2
+
+    # Add paravisaddons-common ctest on salome_test
+    mkdir -p $PREFIX/bin/salome
+    cp -rf $PREFIX/tests/ $PREFIX/bin/salome/test
+}
+
 function s-paravisaddons-common-prefix()
 {
     echo NONE

--- a/scripts.d/s-salome
+++ b/scripts.d/s-salome
@@ -345,14 +345,25 @@ EOF
     for module in $(s-salome-prerequisite-modules); do
         MODULE_PATH=$SCBI_BDIR/$module/build/install
 
-        if [[ "$module" == "samples" ]]; then
-            echo "   <samples path=\"$MODULE_PATH\"/>"        >> $FILE
-        elif [[ "$module" == "medcoupling" ]]; then
-            echo "   <extra_tests>"                           >> $FILE
-            echo "      <extra_test name='MEDCOUPLING'"       >> $FILE
-            echo "             path=\"$MODULE_PATH/tests\"/>" >> $FILE
-            echo "   </extra_tests>"                          >> $FILE
-        fi
+	case "$module" in
+		"samples")
+			echo "   <samples path=\"$MODULE_PATH\"/>"        >> $FILE
+			;;
+		*"medcoupling"*)
+			echo "   <extra_tests>"                           >> $FILE
+			echo "      <extra_test name='MEDCOUPLING'"       >> $FILE
+			echo "             path=\"$MODULE_PATH/tests\"/>" >> $FILE
+			echo "   </extra_tests>"                          >> $FILE
+			;;
+		*"paravisaddons-common"*)
+			echo "   <extra_tests>"                           >> $FILE
+                        echo "      <extra_test name='paravisaddons-common'"       >> $FILE
+                        echo "             path=\"$MODULE_PATH/tests\"/>" >> $FILE
+                        echo "   </extra_tests>"                          >> $FILE
+                        ;;
+		*)
+			;;
+	esac
     done
 
     echo "</application>"                                     >> $FILE

--- a/scripts.d/s-salome
+++ b/scripts.d/s-salome
@@ -153,6 +153,9 @@ function build-salome-prerequisites()
                     *INCLUDE_DIR|*INCLUDE_DIRS|LIBRARY_PATH)
                 ;;
 
+                SalomeAppConfig|SALOME_MODULES)
+                ;;
+
                 *)
                     VSET=${VAR}_set
                     echo export $VAR=${REL_DIR}${!VSET:+:\$${VAR}} >> $FILE
@@ -250,6 +253,9 @@ function build-salome-context()
 
                 C_INCLUDE_PATH|CPLUS_INCLUDE_PATH|CMAKE_*\
                     |*INCLUDE_DIR|*INCLUDE_DIRS|LIBRARY_PATH)
+                    ;;
+
+                SalomeAppConfig|SALOME_MODULES)
                     ;;
 
                 *)


### PR DESCRIPTION
Salut Pascal,

Pour les tests medcalc, j'ai trouvé une autre solution plus propre. En gros, j'ai rajouté 2 variables (SalomeAppConfig, SALOME_MODULES) dans s-salome-openturns pour que le module OT puisse fonctionner correctement dans salome-ng. Par contre, ce modif, par incident, écrase la variable  SalomeAppConfig défini dans env.d/configGui.cfg qui est généré par **appli_gen.py de KERNEL**. Et donc, les tests MEDCALC plantent à cause de l'absence de FIELDS dans SalomeAppConfig.

A+