### PR TITLE
Some correction for smesh and distene(double quotes)

### DIFF
--- a/scripts.d/s-salome-bin
+++ b/scripts.d/s-salome-bin
@@ -104,7 +104,4 @@ function s-salome-bin-linux-env()
 
     export PYTHON_VERSION=$(python3 --version | cut -d' ' -f2 | cut -c1-3)
 
-    add-to-var PYTHONPATH $SMESH_ROOT_DIR/share/salome/plugins/smesh
-    add-to-var PYTHONPATH $SMESH_ROOT_DIR/share/salome/plugins/smesh/Verima
-    add-to-var PYTHONPATH $SMESH_ROOT_DIR/share/salome/plugins/smesh/MacMesh
 }

--- a/scripts.d/s-salome-kernel
+++ b/scripts.d/s-salome-kernel
@@ -104,7 +104,7 @@ function s-salome-kernel-common-config-options()
     echo -DCMAKE_PREFIX_PATH=$SCBI_BDIR/install
     echo -DSALOME_USE_LIBBATCH=ON
     echo -DSALOME_USE_64BIT_IDS=ON
-    echo -DSALOME_BUILD_TESTS=OFF
+    echo -DSALOME_BUILD_TESTS=ON
     echo -DSWIG_EXECUTABLE:PATH=$(command -v swig)
     echo ${DISDOC:+"-DSALOME_BUILD_DOC=OFF"}
     echo ${CDEBUG:+"-DSALOME_CMAKE_DEBUG=ON"}

--- a/scripts.d/s-salome-ng
+++ b/scripts.d/s-salome-ng
@@ -166,6 +166,9 @@ function setup-salome-ng-env()
         echo '   context.setVariable(r"ROOT_SALOME_INSTALL", root_dir, overwrite=True)' >> $PFILE
         echo '   context.setVariable(r"MESHGEMS_VERSION", r"213", overwrite=True)' >> $PFILE
         echo '   context.setVariable(r"SALOME_MG_KEYGEN_LIB_PATH", r"https://meshgems-licence.retd.edf.fr/MESHGEMS" + r"${MESHGEMS_VERSION}", overwrite=True)' >> $PFILE
+        echo '   context.addToPythonPath(r"${SMESH_ROOT_DIR}/share/salome/plugins/smesh")' >> $PFILE
+        echo '   context.addToPythonPath(r"${SMESH_ROOT_DIR}/share/salome/plugins/smesh/MacMesh")' >> $PFILE
+        echo '   context.addToPythonPath(r"${SMESH_ROOT_DIR}/share/salome/plugins/smesh/Verima")' >> $PFILE
 
         #  keep current PATH setting
         PATH_set=IS_SET

--- a/scripts.d/s-salome-ng
+++ b/scripts.d/s-salome-ng
@@ -95,7 +95,11 @@ function setup-salome-ng-env()
                     ;;
                 *)
                     if [[ "$REL_PDIR" == "$VALUE" ]]; then
-                        echo "   context.setVariable(r\"$VAR\", r\"$VALUE\", overwrite=True)" >> $PFILE
+                        if [[ $VALUE == \"*\" ]]; then
+                            echo "   context.setVariable(r\"$VAR\", r$VALUE, overwrite=True)" >> $PFILE
+                        else
+                            echo "   context.setVariable(r\"$VAR\", r\"$VALUE\", overwrite=True)" >> $PFILE
+                        fi
                     else
                         echo "   context.setVariable(r\"$VAR\", $DVAR, overwrite=True)"     >> $PFILE
                     fi

--- a/scripts.d/s-yacs
+++ b/scripts.d/s-yacs
@@ -65,7 +65,7 @@ function s-yacs-config()
     cmake -DCMAKE_INSTALL_PREFIX=$PREFIX -DSALOME_BUILD_GUI=ON \
           -DSWIG_EXECUTABLE:PATH=$(command -v swig) \
           -DCMAKE_BUILD_TYPE=$(get-build-type CMAKE Release) \
-          -DSALOME_BUILD_TESTS=OFF \
+          -DSALOME_BUILD_TESTS=ON \
           ${CDEBUG:+"-DSALOME_CMAKE_DEBUG=ON"} \
           ${DISDOC:+"-DSALOME_BUILD_DOC=OFF"} \
           ../src


### PR DESCRIPTION
Pascal,
La variable DLIM8VAR avec le "double quotes"  (" \" * \" ") pose un problème sur le fichier python output extra.env.d/8_s_distene.py.
Voici le problème:
context.setVariable(r"DLIM8VAR", r**""**dlim8 1:1:29030@10.122.51.15/005056010130::9de2ce714bcb5ec8ced9926a1087298ebeca6affe852286633abe41cb4a85b4b**""**, overwrite=True)
Comme tu vois, il y a 2 **""**

A+