### PR TITLE
s-salome: application patch for salome_version.py and yacs tests

### DIFF
--- a/scripts.d/s-salome
+++ b/scripts.d/s-salome
@@ -452,6 +452,15 @@ function s-salome-wrapup()
             local APP=$SCBI_BDIR/s-salome/application
             cd $APP
 
+            # copy VERSION file of KERNEL on salome application
+
+            rm -rf ./bin/salome/VERSION && cp $SCBI_BDIR/s-salome-kernel/build/install/bin/salome/VERSION ./bin/salome/
+
+            # fix broken symlink of yacs tests data
+
+            (cd ./bin/salome/test/YACS/yacsloader_swig/ && rm -rf samples && ln -s ../../../../../share/salome/yacssamples samples)
+            (cd ./bin/salome/test/YACS/yacsloader/ && rm -rf samples && ln -s ../../../../../share/salome/yacssamples samples)
+
             # generate the scbi_versions.txt for tracability
 
             scbi --version > .scbi_versions.txt


### PR DESCRIPTION
Hello Pascal,

C'est pour les tests NRT et le test YACS.

A+