### PR TITLE
s-paraview and .plan: Fix for paraview with Redhat in ng config

### DIFF
--- a/scripts.d/.plan-ng-cluster-dev
+++ b/scripts.d/.plan-ng-cluster-dev
@@ -3,7 +3,8 @@
 @load ng-dev
 
 s-medcoupling/ng.mpi.ptscotch
-s-paraview/ng.mpi.ospray.gdal:#v5.9.0
+#s-paraview/ng.mpi.ospray.gdal:#v5.9.0
+s-paraview/ng.mpi:#v5.9.0
 s-paravis/ng.mpi
 
 s-ptscotch:skip
@@ -13,6 +14,6 @@ s-embree:skip
 s-ospray:skip
 s-gdal:skip
 s-netcdf:skip
-s-cmake/auto:#3.14.4
+s-cmake:#3.14.4
 
 @on rhl use s-openmpi/cronos

--- a/scripts.d/.plan-ng-dev
+++ b/scripts.d/.plan-ng-dev
@@ -93,6 +93,6 @@ s-paraview/ng.mpi.ospray.gdal:v5.9.0
         s-salome-tar:#master:CO8
         s-zeromq:skip
         s-melissa:skip
-        s-cmake/auto:#3.12.1
+        s-cmake/auto:#3.14.4
         s-python-modules:skip
 ]

--- a/scripts.d/s-paraview
+++ b/scripts.d/s-paraview
@@ -28,13 +28,12 @@ function s-paraview-patches()
 
     [[ $REF =~ "5.8" ]] && echo paraview-autoload.patch
     [[ $REF =~ "5.9" ]] && echo paraview-5.9.patch
-    [[ $REF =~ "5.9" ]] && echo paraview-5.9-cmake3.12.patch
 }
 
 function s-paraview-ng-build-depends()
 {
     echo s-salome-bin
-    # To avoid Paraview configuration issue with cmake < 3.13
+    # To avoid Paraview configuration issue with cmake < 3.13 to detect cmake native
     echo s-cmake
 }
 


### PR DESCRIPTION
Here you can find the last commit to build paraview on redhat with next generation