### PR TITLE
.plan-cluster-ng-dev: using paraview archive of CEA

### DIFF
--- a/scripts.d/.plan-cluster-ng-dev
+++ b/scripts.d/.plan-cluster-ng-dev
@@ -3,7 +3,7 @@
 @load ng-dev
 
 s-medcoupling/ng.mpi.ptscotch
-s-paraview/ng.mpi.ospray.gdal:#v5.11.0
+s-paraview/ng.mpi.ospray.gdal:#5.11.0-08c5d057a8
 s-paravis/ng.mpi
 
 s-ptscotch:skip


### PR DESCRIPTION
Pascal, 
Je veux utiliser le targz ParaView-5.11.0-08c5d057a8.tar.gz récupéré dans le tgz de CEA pour cronos. Pourrais tu merger ce commit dans la branche esy/clusterForV910 du dépôt principal?
Merci