### PR TITLE
.plan-cluster-ng-v910: minor correction

### DIFF
--- a/scripts.d/.plan-cluster-ng-v910
+++ b/scripts.d/.plan-cluster-ng-v910
@@ -3,7 +3,7 @@
 @load ng-v910
 
 s-medcoupling/ng.mpi.ptscotch
-s-paraview/ng.mpi.ospray.gdal.catalyst:#v5.11.0
+s-paraview/ng.mpi.ospray.gdal.catalyst:#5.11.0
 s-paravis/ng.mpi
 
 s-ptscotch:skip


### PR DESCRIPTION
    to be able to compile salome on hpc with paraview archive embedded in salome targz of CEA