### PR TITLE
.plan-cluster-ng-dev and .plan-ng-dev: s-paraview -> #5.11.0

### DIFF
--- a/scripts.d/.plan-cluster-ng-dev
+++ b/scripts.d/.plan-cluster-ng-dev
@@ -3,7 +3,7 @@
 @load ng-dev
 
 s-medcoupling/ng.mpi.ptscotch
-s-paraview/ng.mpi.ospray.gdal:#5.11.0-RC2
+s-paraview/ng.mpi.ospray.gdal:#5.11.0
 s-paravis/ng.mpi
 s-catalyst/ng:2.0-431a8a1
 

--- a/scripts.d/.plan-ng-dev
+++ b/scripts.d/.plan-ng-dev
@@ -45,7 +45,7 @@ s-salome-ng:dev
 #  For some modules we may need more than just the ng variant
 #  Override the referrence below.
 
-s-paraview/ng.mpi.ospray.gdal:#5.11.0-RC2
+s-paraview/ng.mpi.ospray.gdal:#5.11.0
 s-medcoupling/ng.mpi.ptscotch:#
 s-paravis/ng.mpi
 


### PR DESCRIPTION
To se 5.11.0 version instead of 5.11.0-RC2 for Paraview in dev version