### PR TITLE
cfd & hydro: Remove cmake version to use the one in main dev plan.

### DIFF
--- a/scripts.d/.plan-cfd-ng-dev
+++ b/scripts.d/.plan-cfd-ng-dev
@@ -4,7 +4,6 @@
 
 s-salome-ng/neptune.cfd
 
-s-cmake:#3.14.4
 s-libccmio:92f08637
 s-coolprop:#6.1.0
 s-neptune:master

--- a/scripts.d/.plan-hydro-ng-dev
+++ b/scripts.d/.plan-hydro-ng-dev
@@ -4,7 +4,6 @@
 
 s-salome-ng/hydro:-dev
 
-s-cmake:#3.14.4
 s-libecw2:#
 s-metis-hydro:#5.1.0
 s-python-modules/ng.wand.pyaml.pyproj.telemac.metadata.toml:master


### PR DESCRIPTION
With this patch CFD & HYDRO will use the more recent CMake version 3.24.3 instead of 3.14.4.