### PR TITLE
s-salome-configuration: Add PYQT5_NOT_MASTER variable

### DIFF
--- a/scripts.d/s-salome-configuration
+++ b/scripts.d/s-salome-configuration
@@ -54,6 +54,12 @@ function s-salome-configuration-env()
 
     set-var SALOME_ALPHA_BUFFER_SIZE_VALUE 1
     set-var SALOME_ACTOR_DELEGATE_TO_VTK   1
+
+    # Following variable is set there as it is needed for standard
+    # and NG build. The plug-in s-pyqt is not used in the later
+    # mode.
+
+    set-var PYQT5_NOT_MASTER 1
 }
 
 function s-salome-configuration-ngwin-env()


### PR DESCRIPTION
PYQT5_NOT_MASTER to be used by pyqt5 patch