### PR TITLE
.plan-cfd-ng-dev: skip cmake for deb9

### DIFF
--- a/scripts.d/.plan-cfd-ng-dev
+++ b/scripts.d/.plan-cfd-ng-dev
@@ -20,3 +20,7 @@ s-neptune:master
 [ = deb,10
     s-cmake:skip
 ]
+
+[ = deb,9
+    s-cmake:skip
+]


### PR DESCRIPTION
To fix deb9 compile with cfd-ng-dev