### PR TITLE
.plan-cfd-ng-dev: CoolProp 6.1.0 > 6.4.3

### DIFF
--- a/scripts.d/.plan-cfd-ng-dev
+++ b/scripts.d/.plan-cfd-ng-dev
@@ -5,7 +5,7 @@
 s-salome-ng/neptune.cfd
 
 s-libccmio:92f08637
-s-coolprop:#6.1.0
+s-coolprop:#6.4.3
 s-neptune:master
 
 [


### PR DESCRIPTION
Change CoolProp version for 6.4.3 in CFD plan