### PR TITLE
.env-cluster-ng-v912: headless for cronos

### DIFF
--- a/scripts.d/.env-cluster-ng-v912
+++ b/scripts.d/.env-cluster-ng-v912
@@ -20,12 +20,15 @@ SCBI_CLANG_VERSION=12
 #
 if [[ $HOSTNAME =~ gafront* ]]; then
     SCBI_ROOT=/tmp/$USER/dev
+    SCBI_PLAN=cluster-ng-v912
 elif [[ $HOSTNAME =~ crfront* ]]; then
     SCBI_ROOT=/scratch/users/$USER/dev
-    SCBI_EXTRA_NG_MODULES=${SCBI_EXTRA_NG_MODULES:-s-paraview:s-medcoupling:s-paravis}
+    SCBI_EXTRA_NG_MODULES=${SCBI_EXTRA_NG_MODULES:-s-paraview:s-medcoupling:s-paravis:s-paravisaddons-common}
+    SCBI_PLAN=cluster-ng-v912/headless
 else
     SCBI_ROOT=$HOME/dev
     SCBI_EXTRA_NG_MODULES=${SCBI_EXTRA_NG_MODULES:-s-paraview:s-medcoupling:s-paravis}
+    SCBI_PLAN=cluster-ng-v912
 fi
 
 #  Needed for YACS_KERNEL_IN and YACS_KERNEL_OUT tests
@@ -37,4 +40,3 @@ fi
 
 SCBI_BDIR=$SCBI_ROOT/build-salome-v912
 SCBI_GIT_REPO=$HOME/dev/git
-SCBI_PLAN=cluster-ng-v912


### PR DESCRIPTION
Pascal,

Salome en mode headless est compilé bien sur cronos. J'ai fait le test visu et ça marche!
Peux tu l'intégrer dans la branche principale?
Merci,

Duc